### PR TITLE
Installation correction in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Variants requires the `variants` feature to be enabled.
 
 #### With variants
 ```bash
-cargo add tailwind-fuse --features variants
+cargo add tailwind-fuse --features variant
 ```
 
 #### Without variants


### PR DESCRIPTION
Feature name should be `variant` singular

Otherwise we get the following error:

<img width="1015" alt="image" src="https://github.com/gaucho-labs/tailwind-fuse/assets/61635505/1a4e9982-6828-4fc4-b9be-28111e62ec65">
