### PR TITLE
Collision Fixes

### DIFF
--- a/fuse/src/core/merge/get_collision_id.rs
+++ b/fuse/src/core/merge/get_collision_id.rs
@@ -743,7 +743,9 @@ pub fn get_collision_id(classes: &[&str], arbitrary: &str) -> Result<&'static st
         ["stroke"] if is_valid_length(arbitrary) => Ok("stroke-width"),
 
         // https://tailwindcss.com/docs/stroke
-        ["stroke", ..] => Ok("stroke"),
+        ["stroke", ..]=> {
+            Ok("stroke")
+        },
 
         // https://tailwindcss.com/docs/screen-readers
         ["sr", "only"] | ["not", "sr", "only"] => Ok("screen-readers"),
@@ -798,7 +800,7 @@ fn valid_top_right_bottom_left(mode: &str) -> bool {
     mode == "auto"
         || mode == "full"
         || mode == "px"
-        || parse_single_digit_decimal(mode).is_some()
+        || validators::parse_single_digit_decimal(mode)
         || parse_fraction(mode).is_some()
 }
 
@@ -809,28 +811,19 @@ fn valid_break_after(mode: &str) -> bool {
     )
 }
 
+// Need starts_with for this https://tailwindcss.com/docs/font-size#setting-the-line-height
 fn valid_text_size(mode: &str) -> bool {
     mode == "base"
+        || mode.starts_with("xs")
         || mode.ends_with("xs")
+        || mode.starts_with("sm")
         || mode.ends_with("sm")
+        || mode.starts_with("md")
         || mode.ends_with("md")
+        || mode.starts_with("lg")
         || mode.ends_with("lg")
+        || mode.starts_with("xl")
         || mode.ends_with("xl")
-}
-
-// parses 1.5 but not 1.55
-fn parse_single_digit_decimal(input: &str) -> Option<()> {
-    if input.len() == 1 {
-        let _ = input.parse::<usize>().ok()?;
-        Some(())
-    } else if input.len() == 3 {
-        let (l, r) = input.split_once('.')?;
-        let _ = l.parse::<usize>().ok()?;
-        let _ = r.parse::<usize>().ok()?;
-        Some(())
-    } else {
-        None
-    }
 }
 
 fn parse_fraction_or_usize(input: &str) -> bool {
@@ -909,8 +902,8 @@ mod test {
         assert!(is_valid_length("10%"));
         assert!(is_valid_length("100rem"));
 
-        assert!(!is_valid_length("10"), "needs unit");
         assert!(!is_valid_length("hsl(350_80%_0%)"), "no color");
+        assert!(!is_valid_length("--my-0"), "double negative");
     }
 
     #[test]

--- a/fuse/src/core/merge/get_collisions.rs
+++ b/fuse/src/core/merge/get_collisions.rs
@@ -34,7 +34,7 @@ pub(crate) fn get_collisions(collision_id: &str) -> Option<Vec<&'static str>> {
         "margin-x" => Some(vec!["margin-right", "margin-left"]),
         "margin-y" => Some(vec!["margin-top", "margin-bottom"]),
         "size" => Some(vec!["width", "height"]),
-        "font-size" => Some(vec!["leading"]),
+        "font-size" => Some(vec!["line-height"]),
         "fvn-normal" => Some(vec![
             "fvn-ordinal",
             "fvn-slashed-zero",

--- a/fuse/src/core/merge/validators.rs
+++ b/fuse/src/core/merge/validators.rs
@@ -12,14 +12,17 @@ pub mod length {
     use super::*;
 
     pub fn parse(input: &str) -> IResult<&str, &str> {
-        alt((tag("0"), number, unit, functional_notation))(input)
+        alt((tag("0"), number, functional_notation))(input)
     }
 
     // Parser for numeric values
     fn number(input: &str) -> IResult<&str, &str> {
         recognize(pair(
-            take_while1(|c: char| c.is_ascii_digit() || c == '.' || c == '-'),
-            unit,
+            pair(
+                opt(char('-')),
+                take_while1(|c: char| c.is_ascii_digit() || c == '.'),
+            ),
+            opt(unit),
         ))(input)
     }
 
@@ -73,6 +76,14 @@ pub mod length {
         let input = "calc(theme(fontSize.4xl)/1.125)";
         let (_, result) = parse(input).unwrap();
         assert_eq!(result, "theme(fontSize.4xl)/1.125");
+    }
+
+    #[test]
+    fn num_len() {
+        let input = "1";
+        assert!('1'.is_ascii_digit());
+        let result = number(input).unwrap();
+        assert_eq!(result, ("", "1"));
     }
 }
 
@@ -172,4 +183,60 @@ pub mod image {
     fn arguments(input: &str) -> IResult<&str, &str> {
         take_while1(|c: char| c != ')')(input)
     }
+}
+
+pub fn parse_single_digit_decimal(input: &str) -> bool {
+    if input.is_empty() {
+        return false;
+    }
+
+    let mut dot_index = None;
+    for (i, c) in input.char_indices() {
+        if c == '.' {
+            if dot_index.is_some() || i == 0 || i == input.len() - 1 || input.len() - i != 2 {
+                return false;
+            }
+            dot_index = Some(i);
+        } else if !c.is_ascii_digit() {
+            return false;
+        }
+    }
+
+    true
+}
+
+#[test]
+fn test_valid_single_digit_decimal() {
+    assert!(parse_single_digit_decimal("1.5"));
+    assert!(parse_single_digit_decimal("11.5"));
+    assert!(parse_single_digit_decimal("0.0"));
+    assert!(parse_single_digit_decimal("9.9"));
+    assert!(parse_single_digit_decimal("123"));
+    assert!(parse_single_digit_decimal("0"));
+    assert!(parse_single_digit_decimal("1"));
+    assert!(parse_single_digit_decimal("12345"));
+    assert!(parse_single_digit_decimal("9.0"));
+    assert!(parse_single_digit_decimal("0.9"));
+}
+
+#[test]
+fn test_invalid_single_digit_decimal() {
+    assert!(!parse_single_digit_decimal(""));
+    assert!(!parse_single_digit_decimal("1.55"));
+    assert!(!parse_single_digit_decimal("11.55"));
+    assert!(!parse_single_digit_decimal("1."));
+    assert!(!parse_single_digit_decimal(".5"));
+    assert!(!parse_single_digit_decimal("1.5.5"));
+    assert!(!parse_single_digit_decimal("a.5"));
+    assert!(!parse_single_digit_decimal("1.a"));
+    assert!(!parse_single_digit_decimal("1 .5"));
+    assert!(!parse_single_digit_decimal("1. 5"));
+    assert!(!parse_single_digit_decimal("-1.5"));
+    assert!(!parse_single_digit_decimal("+1.5"));
+    assert!(!parse_single_digit_decimal("1.5e3"));
+    assert!(!parse_single_digit_decimal("1.5E3"));
+    assert!(!parse_single_digit_decimal("1.5f"));
+    assert!(!parse_single_digit_decimal("1.5d"));
+    assert!(!parse_single_digit_decimal("1,5"));
+    assert!(!parse_single_digit_decimal("1..5"));
 }

--- a/fuse/tests/group-conflicts.rs
+++ b/fuse/tests/group-conflicts.rs
@@ -205,3 +205,8 @@ fn stroke_width() {
 fn handles_negative_value_conflicts_correctly() {
     assert_eq!(tw_merge("-top-12 -top-2000"), "-top-2000");
 }
+
+#[test]
+fn tailwind_3_4() {
+    assert_eq!(tw_merge("text-red text-lg/8"), "text-red text-lg/8");
+}

--- a/fuse/tests/group-conflicts.rs
+++ b/fuse/tests/group-conflicts.rs
@@ -179,3 +179,29 @@ fn line_clamp_classes_do_create_conflicts_correctly() {
         "line-clamp-1 overflow-auto inline"
     );
 }
+
+#[test]
+fn test_line_height_font_size() {
+    assert_eq!(tw_merge("leading-9 text-lg"), "text-lg");
+}
+
+#[test]
+fn text_color_font_size() {
+    assert_eq!(tw_merge("text-red-500 text-lg"), "text-red-500 text-lg");
+
+    // https://tailwindcss.com/docs/font-size#setting-the-line-height
+    assert_eq!(
+        tw_merge("text-red-500/10 text-lg/9"),
+        "text-red-500/10 text-lg/9"
+    );
+}
+
+#[test]
+fn stroke_width() {
+    assert_eq!(tw_merge("stroke-2 stroke-[3]"), "stroke-[3]");
+}
+
+#[test]
+fn handles_negative_value_conflicts_correctly() {
+    assert_eq!(tw_merge("-top-12 -top-2000"), "-top-2000");
+}

--- a/fuse/tests/merge.rs
+++ b/fuse/tests/merge.rs
@@ -436,3 +436,10 @@ fn columns() {
     let result = tw_merge(class);
     assert_eq!(result, "columns-[2rem]");
 }
+
+#[test]
+fn something() {
+    let class = "[&>*]:[color:red] [&>*]:[color:blue]";
+    let result = tw_merge(class);
+    assert_eq!(result, "[&>*]:[color:blue]");
+}

--- a/fuse/tests/merge.rs
+++ b/fuse/tests/merge.rs
@@ -438,8 +438,27 @@ fn columns() {
 }
 
 #[test]
-fn something() {
+fn arbitrary_property_conflicts() {
     let class = "[&>*]:[color:red] [&>*]:[color:blue]";
     let result = tw_merge(class);
     assert_eq!(result, "[&>*]:[color:blue]");
+
+    let class = "![some:prop] [some:other] [some:one] ![some:another]";
+    let result = tw_merge(class);
+    assert_eq!(result, "[some:one] ![some:another]");
+
+    let class = "hover:[paint-order:markers] hover:[paint-order:normal]";
+    let result = tw_merge(class);
+    assert_eq!(result, "hover:[paint-order:normal]");
+}
+
+#[test]
+fn test_negative_values() {
+    let class = "top-12 -top-69";
+    let result = tw_merge(class);
+    assert_eq!(result, "-top-69");
+
+    let class = "-top-12 -top-2000";
+    let result = tw_merge(class);
+    assert_eq!(result, "-top-2000");
 }

--- a/fuse/tests/override.rs
+++ b/fuse/tests/override.rs
@@ -1,7 +1,4 @@
-use tailwind_fuse::{
-    merge::{tw_merge_with_options, tw_merge_with_override, MergeOptions},
-    tw_merge,
-};
+use tailwind_fuse::merge::{tw_merge_with_options, tw_merge_with_override, MergeOptions};
 
 #[test]
 fn test_collisions() {
@@ -59,16 +56,4 @@ fn test_override_config() {
         class, result,
         "No conflict because non-prefix is not considered tailwind class"
     )
-}
-
-#[test]
-fn test_override_config_macro() {
-    let config = MergeOptions {
-        prefix: "tw-",
-        separator: "|",
-    };
-
-    let result = tw_merge!(config => "hover|lg|tw-bg-blue-100", "hover|lg|tw-bg-red-500");
-
-    assert_eq!("hover|lg|tw-bg-red-500", result);
 }

--- a/fuse/tests/override.rs
+++ b/fuse/tests/override.rs
@@ -1,4 +1,7 @@
-use tailwind_fuse::merge::{tw_merge_with_options, tw_merge_with_override, MergeOptions};
+use tailwind_fuse::{
+    merge::{tw_merge_with_options, tw_merge_with_override, MergeOptions},
+    tw_merge,
+};
 
 #[test]
 fn test_collisions() {
@@ -56,4 +59,16 @@ fn test_override_config() {
         class, result,
         "No conflict because non-prefix is not considered tailwind class"
     )
+}
+
+#[test]
+fn test_override_config_macro() {
+    let config = MergeOptions {
+        prefix: "tw-",
+        separator: "|",
+    };
+
+    let result = tw_merge!(config => "hover|lg|tw-bg-blue-100", "hover|lg|tw-bg-red-500");
+
+    assert_eq!("hover|lg|tw-bg-red-500", result);
 }


### PR DESCRIPTION
- line-height and font-size
- arbitrary values
- Single digit decimal parsing

Fixes all non prefix-modifier order bugs uncovered in https://github.com/gaucho-labs/tailwind-fuse/issues/14 

### Reasoning for keeping unique ordering of prefix-modifier from issue:

```diff
--- expected
+++ actual
@@ -1 +1 @@
-"hover:block focus:hover:inline"
+"hover:block hover:focus:inline focus:hover:inline"
```

These two prefix modifiers actually create different tailwind classes, so I elected to handle them separately. If they were the same, wouldn't they only generate one tailwind class? I am open to hearing why they should be considered the same though.

```css
.focus\:hover\:inline:hover:focus{
  display: inline
}

.hover\:focus\:inline:focus:hover{
  display: inline
}
```
