### PR TITLE
Variant API Improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,19 +13,20 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - name: Build
-      run: cargo build --verbose
-    - name: Run tests
-      run: cargo test --verbose --all-features
-    - name: Run clippy
-      run: cargo clippy --verbose -- -D warnings
-    - name: Check README.md
-      id: check_readme
-      run: |
-        cargo install cargo-rdme
-        cargo rdme --check
-      continue-on-error: true
-    - name: Warning for README.md check failure
-      if: failure() && steps.check_readme.outcome == 'failure'
-      run: echo "README.md check failed. Please run 'cargo rdme' to update your README.md based on doc comments."
+      - uses: actions/checkout@v3
+      - name: Build
+        run: cargo build --verbose
+      - name: Run tests
+        run: cargo test --verbose --all-features
+      - name: Run clippy
+        run: cargo clippy --verbose -- -D warnings
+      - name: Check README.md
+        run: |
+          set -e
+          cargo install cargo-rdme
+          cargo rdme --check
+      - name: Warning for README.md check failure
+        if: ${{ failure() }}
+        run: |
+          echo "README.md check failed. Please run 'cargo rdme' to update your README.md based on doc comments."
+          exit 1

--- a/README.md
+++ b/README.md
@@ -122,18 +122,18 @@ button.with_class("bg-green-500");
 ```
 
 ### Builder Syntax
-You access the builder using the `variants` method. Every variant that is not provided will be replaced with the default variant.
+You access the builder using the `builder` method. Every variant that is not provided will be replaced with the default variant.
 
 ```rust
 
 // h-8 px-3 bg-red-500 text-red-100
-let class = Btn::variant()
+let class = Btn::builder()
     .size(BtnSize::Sm)
     .color(BtnColor::Red)
     .to_class();
 
 // h-8 px-3 text-red-100 bg-green-500
-let class = Btn::variant()
+let class = Btn::builder()
     .size(BtnSize::Sm)
     .color(BtnColor::Red)
     .with_class("bg-green-500");

--- a/README.md
+++ b/README.md
@@ -16,14 +16,14 @@ Two main utils are included in this crate:
 
 ## Installation
 
-Variants requires the `variants` feature to be enabled.
+Variants requires the `variant` feature to be enabled.
 
-#### With variants
+#### With variant
 ```bash
 cargo add tailwind-fuse --features variant
 ```
 
-#### Without variants
+#### Without variant
 ```bash
 cargo add tailwind-fuse
 ```
@@ -32,6 +32,9 @@ cargo add tailwind-fuse
 
 You can use [`tw_join!`] to join Tailwind classes, and [`tw_merge!`] to merge Tailwind Classes handling conflicts.
 
+
+You can use anything that implements [`AsRef<str>`] or [`AsTailwindClass`]
+
 ```rust
 use tailwind_fuse::*;
 
@@ -39,26 +42,13 @@ use tailwind_fuse::*;
 // "flex items-center justify-center"
 let joined_class = tw_join!("flex items-center", "justify-center");
 
-// You can use Option to handle conditional rendering
-// You can pass in &str, String, Option<String>, or Option<&str>
-// "text-sm font-bold"
-let classes = tw_join!(
-    "text-sm",
-    Some("font-bold"),
-    None::<String>,
-    Some("ring").filter(|_| false),
-    Some(" "),
-    "".to_string(),
-);
 
 // Conflict resolution
 // Right most class takes precedence
-// p-4
-let merged_class = tw_merge!("py-2 px-4", "p-4");
+assert_eq!("p-4", tw_merge!("py-2 px-4", "p-4"));
 
 // Refinements are permitted
-// p-4 py-2
-let merged_class = tw_merge!("p-4", "py-2");
+assert_eq!("p-4 py-2", tw_merge!("p-4", "py-2"));
 ```
 
 ## Usage: Variants
@@ -114,29 +104,40 @@ let button = Btn {
     size: BtnSize::Default,
     color: BtnColor::Blue,
 };
-// h-9 px-4 py-2 bg-blue-500 text-blue-100
-button.to_class();
-// Conflicts are resolved.
-// h-9 px-4 py-2 text-blue-100 bg-green-500
-button.with_class("bg-green-500");
+
+assert_eq!(
+   "flex h-9 px-4 py-2 bg-blue-500 text-blue-100",
+   button.to_class()
+);
+
+// Conflicts are resolved (bg-blue-500 is knocked out in favor of override)
+assert_eq!(
+   "flex h-9 px-4 py-2 text-blue-100 bg-green-500",
+   button.with_class("bg-green-500")
+);
 ```
 
 ### Builder Syntax
-You access the builder using the `builder` method. Every variant that is not provided will be replaced with the default variant.
+You access the builder using the `variants` method. Every variant that is not provided will be replaced with the default variant.
 
 ```rust
 
-// h-8 px-3 bg-red-500 text-red-100
-let class = Btn::builder()
-    .size(BtnSize::Sm)
-    .color(BtnColor::Red)
-    .to_class();
+assert_eq!(
+   "flex h-8 px-3 bg-red-500 text-red-100",
+   Btn::builder()
+      .size(BtnSize::Sm)
+      .color(BtnColor::Red)
+      .to_class()
+);
 
-// h-8 px-3 text-red-100 bg-green-500
-let class = Btn::builder()
-    .size(BtnSize::Sm)
-    .color(BtnColor::Red)
-    .with_class("bg-green-500");
+assert_eq!(
+   "flex h-8 px-3 text-red-100 bg-green-500",
+   Btn::builder()
+      .size(BtnSize::Sm)
+      .color(BtnColor::Red)
+      .with_class("bg-green-500")
+);
+
 ```
 
 #### VSCode Intellisense

--- a/example/demo/src/app.rs
+++ b/example/demo/src/app.rs
@@ -143,7 +143,7 @@ fn Header() -> impl IntoView {
         <div class="flex items-center justify-between w-full py-4 px-8">
             <div class="flex items-center">
                 <a
-                    class=ButtonClass::variant()
+                    class=ButtonClass::builder()
                         .size(ButtonSize::Sm)
                         .variant(ButtonVariant::Link)
                         .to_class()
@@ -155,7 +155,7 @@ fn Header() -> impl IntoView {
                 </a>
                 <span> / </span>
                 <a
-                    class=ButtonClass::variant()
+                    class=ButtonClass::builder()
                         .size(ButtonSize::Sm)
                         .variant(ButtonVariant::Link)
                         .to_class()

--- a/fuse/src/core/join.rs
+++ b/fuse/src/core/join.rs
@@ -9,45 +9,45 @@
 macro_rules! tw_join {
      ($item:expr) => {{
         use $crate::AsTailwindClass;
-        let tailwind_class = $item.as_tailwind_class();
+        let tailwind_class = $item.as_class();
         tailwind_class.trim().to_string()
     }};
     ($a:expr, $b:expr) => {{
         use $crate::AsTailwindClass;
         format!(
             "{} {}",
-            $a.as_tailwind_class().trim(),
-            $b.as_tailwind_class().trim()
+            $a.as_class().trim(),
+            $b.as_class().trim()
         )
     }};
     ($a:expr, $b:expr, $c:expr) => {{
         use $crate::AsTailwindClass;
         format!(
             "{} {} {}",
-            $a.as_tailwind_class().trim(),
-            $b.as_tailwind_class().trim(),
-            $c.as_tailwind_class().trim()
+            $a.as_class().trim(),
+            $b.as_class().trim(),
+            $c.as_class().trim()
         )
     }};
     ($a:expr, $b:expr, $c:expr, $d:expr) => {{
         use $crate::AsTailwindClass;
         format!(
             "{} {} {} {}",
-            $a.as_tailwind_class().trim(),
-            $b.as_tailwind_class().trim(),
-            $c.as_tailwind_class().trim(),
-            $d.as_tailwind_class().trim()
+            $a.as_class().trim(),
+            $b.as_class().trim(),
+            $c.as_class().trim(),
+            $d.as_class().trim()
         )
     }};
     ($a:expr, $b:expr, $c:expr, $d:expr, $e:expr) => {{
         use $crate::AsTailwindClass;
         format!(
             "{} {} {} {} {}",
-            $a.as_tailwind_class().trim(),
-            $b.as_tailwind_class().trim(),
-            $c.as_tailwind_class().trim(),
-            $d.as_tailwind_class().trim(),
-            $e.as_tailwind_class().trim()
+            $a.as_class().trim(),
+            $b.as_class().trim(),
+            $c.as_class().trim(),
+            $d.as_class().trim(),
+            $e.as_class().trim()
         )
     }};
     ($($item:expr),+ $(,)?) => {{
@@ -56,7 +56,7 @@ macro_rules! tw_join {
         $(
             // Long lived expressions.
             let class = $item;
-            let class = class.as_tailwind_class();
+            let class = class.as_class();
             let class = class.trim();
             if !class.is_empty() {
                 if !result.is_empty() { result.push(' '); }

--- a/fuse/src/core/join.rs
+++ b/fuse/src/core/join.rs
@@ -14,40 +14,78 @@ macro_rules! tw_join {
     }};
     ($a:expr, $b:expr) => {{
         use $crate::AsTailwindClass;
+        let a = $a;
+        let a_class = a.as_class().trim();
+        let b = $b;
+        let b_class = b.as_class().trim();
         format!(
-            "{} {}",
-            $a.as_class().trim(),
-            $b.as_class().trim()
+            "{}{}{}",
+            a_class,
+            if b_class.is_empty() { "" } else { " " },
+            b_class
         )
     }};
     ($a:expr, $b:expr, $c:expr) => {{
         use $crate::AsTailwindClass;
+        let a = $a;
+        let a_class = a.as_class().trim();
+        let b = $b;
+        let b_class = b.as_class().trim();
+        let c = $c;
+        let c_class = c.as_class().trim();
         format!(
-            "{} {} {}",
-            $a.as_class().trim(),
-            $b.as_class().trim(),
-            $c.as_class().trim()
+            "{}{}{}{}{}",
+            a_class,
+            if b_class.is_empty() { "" } else { " " },
+            b_class,
+            if c_class.is_empty() { "" } else { " " },
+            c_class
         )
     }};
     ($a:expr, $b:expr, $c:expr, $d:expr) => {{
         use $crate::AsTailwindClass;
+        let a = $a;
+        let a_class = a.as_class().trim();
+        let b = $b;
+        let b_class = b.as_class().trim();
+        let c = $c;
+        let c_class = c.as_class().trim();
+        let d = $d;
+        let d_class = d.as_class().trim();
         format!(
-            "{} {} {} {}",
-            $a.as_class().trim(),
-            $b.as_class().trim(),
-            $c.as_class().trim(),
-            $d.as_class().trim()
+            "{}{}{}{}{}{}{}",
+            a_class,
+            if b_class.is_empty() { "" } else { " " },
+            b_class,
+            if c_class.is_empty() { "" } else { " " },
+            c_class,
+            if d_class.is_empty() { "" } else { " " },
+            d_class
         )
     }};
     ($a:expr, $b:expr, $c:expr, $d:expr, $e:expr) => {{
         use $crate::AsTailwindClass;
+        let a = $a;
+        let a_class = a.as_class().trim();
+        let b = $b;
+        let b_class = b.as_class().trim();
+        let c = $c;
+        let c_class = c.as_class().trim();
+        let d = $d;
+        let d_class = d.as_class().trim();
+        let e = $e;
+        let e_class = e.as_class().trim();
         format!(
-            "{} {} {} {} {}",
-            $a.as_class().trim(),
-            $b.as_class().trim(),
-            $c.as_class().trim(),
-            $d.as_class().trim(),
-            $e.as_class().trim()
+            "{}{}{}{}{}{}{}{}{}",
+            a_class,
+            if b_class.is_empty() { "" } else { " " },
+            b_class,
+            if c_class.is_empty() { "" } else { " " },
+            c_class,
+            if d_class.is_empty() { "" } else { " " },
+            d_class,
+            if e_class.is_empty() { "" } else { " " },
+            e_class
         )
     }};
     ($($item:expr),+ $(,)?) => {{
@@ -80,4 +118,5 @@ fn test_tw() {
         tw_join!(" one", "two ", " three".to_string()),
         "one two three"
     );
+    assert_eq!(tw_join!("a", "    ", "b", "c", " "), "a b c");
 }

--- a/fuse/src/core/join.rs
+++ b/fuse/src/core/join.rs
@@ -8,27 +8,21 @@
 #[macro_export]
 macro_rules! tw_join {
      ($item:expr) => {{
-        use $crate::MaybeIntoTailwindClass;
-        let tailwind_class = $item.to_tailwind_class();
-        if let Some(class) = tailwind_class {
-            class.trim().into()
-        } else {
-            String::new()
-        }
+        use $crate::AsTailwindClass;
+        let tailwind_class = $item.as_tailwind_class();
+        tailwind_class.trim().to_string()
     }};
     ($($item:expr),+ $(,)?) => {{
-        use $crate::MaybeIntoTailwindClass;
+        use $crate::AsTailwindClass;
         let mut result = String::new();
         $(
             // Long lived expressions.
-            let item = $item;
-            let tailwind_class = item.to_tailwind_class();
-            if let Some(class) = tailwind_class {
-                let class = class.trim();
-                if !class.is_empty() {
-                    if !result.is_empty() { result.push(' '); }
-                    result.push_str(class);
-                }
+            let class = $item;
+            let class = class.as_tailwind_class();
+            let class = class.trim();
+            if !class.is_empty() {
+                if !result.is_empty() { result.push(' '); }
+                result.push_str(class);
             }
         )*
         result
@@ -37,21 +31,10 @@ macro_rules! tw_join {
 
 #[test]
 fn test_tw() {
-    assert_eq!(tw_join!("hello"), "hello");
-    assert_eq!(tw_join!("one", "two"), "one two")
-}
-
-#[test]
-fn test_option() {
-    let classes = tw_join!(
-        "text-sm",
-        Some("font-bold"),
-        Some("ring").filter(|_| false),
-        None::<String>,
-        "bg-white",
-        Some(" "),
-        "".to_string(),
-        "italic text-green-500"
+    assert_eq!(tw_join!("one"), "one");
+    assert_eq!(tw_join!("one", "two"), "one two");
+    assert_eq!(
+        tw_join!(" one", "two ", " three".to_string()),
+        "one two three"
     );
-    assert_eq!(classes, "text-sm font-bold bg-white italic text-green-500");
 }

--- a/fuse/src/core/join.rs
+++ b/fuse/src/core/join.rs
@@ -1,16 +1,54 @@
 /// Joins the given classes into a single string.
 ///
-/// Items can be of type &[`str`], [`String`], [`Option<&str>`] or [`Option<String>`].
+/// Items can be of type &[`str`] or [`String`].
 ///
 /// If you want to handle conflicts use [`crate::tw_merge!`].
 ///
-/// If you want a custom type to be used with this macro, implement the [`crate::MaybeIntoTailwindClass`] trait.
+/// If you want a custom type to be used with this macro, implement the [`crate::AsTailwindClass`] trait.
 #[macro_export]
 macro_rules! tw_join {
      ($item:expr) => {{
         use $crate::AsTailwindClass;
         let tailwind_class = $item.as_tailwind_class();
         tailwind_class.trim().to_string()
+    }};
+    ($a:expr, $b:expr) => {{
+        use $crate::AsTailwindClass;
+        format!(
+            "{} {}",
+            $a.as_tailwind_class().trim(),
+            $b.as_tailwind_class().trim()
+        )
+    }};
+    ($a:expr, $b:expr, $c:expr) => {{
+        use $crate::AsTailwindClass;
+        format!(
+            "{} {} {}",
+            $a.as_tailwind_class().trim(),
+            $b.as_tailwind_class().trim(),
+            $c.as_tailwind_class().trim()
+        )
+    }};
+    ($a:expr, $b:expr, $c:expr, $d:expr) => {{
+        use $crate::AsTailwindClass;
+        format!(
+            "{} {} {} {}",
+            $a.as_tailwind_class().trim(),
+            $b.as_tailwind_class().trim(),
+            $c.as_tailwind_class().trim(),
+            $d.as_tailwind_class().trim()
+        )
+    }};
+    ($a:expr, $b:expr, $c:expr, $d:expr, $e:expr) => {{
+        use $crate::AsTailwindClass;
+        format!(
+            "{} {} {} {} {}",
+            $a.as_tailwind_class().trim(),
+            $b.as_tailwind_class().trim(),
+            $c.as_tailwind_class().trim(),
+            $d.as_tailwind_class().trim(),
+            $e.as_tailwind_class().trim()
+        )
     }};
     ($($item:expr),+ $(,)?) => {{
         use $crate::AsTailwindClass;
@@ -31,8 +69,13 @@ macro_rules! tw_join {
 
 #[test]
 fn test_tw() {
-    assert_eq!(tw_join!("one"), "one");
-    assert_eq!(tw_join!("one", "two"), "one two");
+    assert_eq!(tw_join!("a"), "a");
+    assert_eq!(tw_join!("a", "b"), "a b");
+    assert_eq!(tw_join!("a", "b", "c"), "a b c");
+    assert_eq!(tw_join!("a", "b", "c", "d"), "a b c d");
+    assert_eq!(tw_join!("a", "b", "c", "d", "e"), "a b c d e");
+    assert_eq!(tw_join!("a", "b", "c", "d", "e", "f"), "a b c d e f");
+
     assert_eq!(
         tw_join!(" one", "two ", " three".to_string()),
         "one two three"

--- a/fuse/src/core/merge/merge_impl.rs
+++ b/fuse/src/core/merge/merge_impl.rs
@@ -110,17 +110,13 @@ struct Collision<'a> {
 impl<'a> Collision<'a> {
     fn check_arbitrary(style: AstStyle<'a>) -> Option<Self> {
         let arbitrary = style.arbitrary?;
-        if arbitrary.contains(':') {
-            let mut parts = arbitrary.split(':');
-            let collision_id = parts.next()?;
-            Some(Self {
-                collision_id,
-                important: style.important,
-                variants: style.variants,
-            })
-        } else {
-            None
-        }
+        let index = arbitrary.find(':')?;
+        let (collision_id, _) = arbitrary.split_at(index);
+        Some(Self {
+            collision_id,
+            important: style.important,
+            variants: style.variants,
+        })
     }
 }
 

--- a/fuse/src/core/mod.rs
+++ b/fuse/src/core/mod.rs
@@ -8,14 +8,14 @@ pub mod merge;
 /// Implement this trait for your type to use it with the [`tw_join!`] and [`tw_merge!`] macros
 pub trait AsTailwindClass {
     /// Extract a Tailwind class
-    fn as_tailwind_class(&self) -> &str;
+    fn as_class(&self) -> &str;
 }
 
 impl<T> AsTailwindClass for T
 where
     T: AsRef<str>,
 {
-    fn as_tailwind_class(&self) -> &str {
+    fn as_class(&self) -> &str {
         self.as_ref()
     }
 }

--- a/fuse/src/core/mod.rs
+++ b/fuse/src/core/mod.rs
@@ -6,12 +6,12 @@ pub mod merge;
 /// Used to extract a &str from a type
 ///
 /// Implement this trait for your type to use it with the [`tw_join!`] and [`tw_merge!`] macros
-pub trait AsTailwindClass<'a> {
+pub trait AsTailwindClass {
     /// Extract a Tailwind class
-    fn as_tailwind_class(&'a self) -> &'a str;
+    fn as_tailwind_class(&self) -> &str;
 }
 
-impl<T> AsTailwindClass<'_> for T
+impl<T> AsTailwindClass for T
 where
     T: AsRef<str>,
 {

--- a/fuse/src/core/mod.rs
+++ b/fuse/src/core/mod.rs
@@ -6,31 +6,16 @@ pub mod merge;
 /// Used to extract a &str from a type
 ///
 /// Implement this trait for your type to use it with the [`tw_join!`] and [`tw_merge!`] macros
-pub trait MaybeIntoTailwindClass<'a> {
-    /// Attempt to extract a Tailwind class
-    fn to_tailwind_class(&'a self) -> Option<&'a str>;
+pub trait AsTailwindClass<'a> {
+    /// Extract a Tailwind class
+    fn as_tailwind_class(&'a self) -> &'a str;
 }
 
-impl<'a> MaybeIntoTailwindClass<'a> for String {
-    fn to_tailwind_class(&'a self) -> Option<&'a str> {
-        Some(self.as_str())
-    }
-}
-
-impl<'a> MaybeIntoTailwindClass<'a> for str {
-    fn to_tailwind_class(&'a self) -> Option<&'a str> {
-        Some(self)
-    }
-}
-
-impl<'a> MaybeIntoTailwindClass<'a> for Option<String> {
-    fn to_tailwind_class(&'a self) -> Option<&'a str> {
-        self.as_deref()
-    }
-}
-
-impl<'a> MaybeIntoTailwindClass<'a> for Option<&'a str> {
-    fn to_tailwind_class(&'a self) -> Option<&'a str> {
-        *self
+impl<T> AsTailwindClass<'_> for T
+where
+    T: AsRef<str>,
+{
+    fn as_tailwind_class(&self) -> &str {
+        self.as_ref()
     }
 }

--- a/fuse/src/lib.rs
+++ b/fuse/src/lib.rs
@@ -32,6 +32,9 @@
 //!
 //! You can use [`tw_join!`] to join Tailwind classes, and [`tw_merge!`] to merge Tailwind Classes handling conflicts.
 //!
+//!
+//! You can use anything that implements [`AsRef<str>`] or [`AsTailwindClass`]
+//!
 //! ```
 //! use tailwind_fuse::*;
 //!
@@ -39,26 +42,13 @@
 //! // "flex items-center justify-center"
 //! let joined_class = tw_join!("flex items-center", "justify-center");
 //!
-//! // You can use Option to handle conditional rendering
-//! // You can pass in &str, String, Option<String>, or Option<&str>
-//! // "text-sm font-bold"
-//! let classes = tw_join!(
-//!     "text-sm",
-//!     Some("font-bold"),
-//!     None::<String>,
-//!     Some("ring").filter(|_| false),
-//!     Some(" "),
-//!     "".to_string(),
-//! );
 //!
 //! // Conflict resolution
 //! // Right most class takes precedence
-//! // p-4
-//! let merged_class = tw_merge!("py-2 px-4", "p-4");
+//! assert_eq!("p-4", tw_merge!("py-2 px-4", "p-4"));
 //!
 //! // Refinements are permitted
-//! // p-4 py-2
-//! let merged_class = tw_merge!("p-4", "py-2");
+//! assert_eq!("p-4 py-2", tw_merge!("p-4", "py-2"));
 //! ```
 //!
 //! ## Usage: Variants
@@ -331,10 +321,8 @@ mod variant {
     ///     Red,
     /// }
     ///
-    /// assert_eq!(BtnColor::Default.to_class(), "hover:brightness-50 bg-blue-500 text-blue-100");
-    ///
-    /// let red_with_class = BtnColor::Red.with_class("flex");
-    /// assert_eq!(red_with_class, "hover:brightness-50 bg-red-500 text-red-100 flex");
+    /// assert_eq!("hover:brightness-50 bg-blue-500 text-blue-100", BtnColor::Default.as_class());
+    /// assert_eq!("hover:brightness-50 bg-red-500 text-red-100", BtnColor::Red.as_class());
     /// ```
     ///
     pub use tailwind_fuse_macro::TwVariant;

--- a/fuse/src/lib.rs
+++ b/fuse/src/lib.rs
@@ -183,13 +183,13 @@
 //! # }
 //!
 //! // h-8 px-3 bg-red-500 text-red-100
-//! let class = Btn::variant()
+//! let class = Btn::builder()
 //!     .size(BtnSize::Sm)
 //!     .color(BtnColor::Red)
 //!     .to_class();
 //!
 //! // h-8 px-3 text-red-100 bg-green-500
-//! let class = Btn::variant()
+//! let class = Btn::builder()
 //!     .size(BtnSize::Sm)
 //!     .color(BtnColor::Red)
 //!     .with_class("bg-green-500");
@@ -211,88 +211,6 @@
 //! }
 //! ```
 //!
-
-/// Derives a class for use with Tailwind CSS in Rust components.
-///
-/// Allows building components with first-class support for Tailwind.
-///
-/// Defaults to using [`crate::tw_merge()`] to resolve conflicts.
-///
-/// Resolves conflicts using the following merge order:
-/// - [`TwClass`] base class
-/// - [`TwVariant`] base class
-/// - [`TwVariant`] enum variant class
-/// - Override class with `with_class`
-///
-/// # Example
-///
-/// ```rust
-/// use tailwind_fuse::*;
-///
-/// #[derive(TwClass, Debug)]
-/// // Optional base class.
-/// #[tw(class = "flex")]
-/// struct Btn {
-///     size: BtnSize,
-///     color: BtnColor,
-/// }
-///
-/// #[derive(TwVariant, Debug)]
-/// enum BtnSize {
-///     #[tw(default, class = "h-9 px-4 py-2")]
-///     Default,
-///     #[tw(class = "h-8 px-3")]
-///     Sm,
-///     #[tw(class = "h-10 px-8")]
-///     Lg,
-/// }
-///
-/// #[derive(TwVariant, Debug)]
-/// enum BtnColor {
-///     #[tw(default, class = "bg-blue-500 text-blue-100")]
-///     Blue,
-///     #[tw(class = "bg-red-500 text-red-100")]
-///     Red,
-/// }
-///
-/// let btn = Btn { size: BtnSize::Default, color: BtnColor::Blue };
-/// assert_eq!(btn.to_class(), "flex h-9 px-4 py-2 bg-blue-500 text-blue-100");
-///
-/// let btn_variant = Btn::variant().color(BtnColor::Red).to_class();
-/// assert_eq!(btn_variant, "flex h-9 px-4 py-2 bg-red-500 text-red-100");
-/// ```
-///
-#[cfg(feature = "variant")]
-pub use tailwind_fuse_macro::TwClass;
-
-/// Represents a customizable property (variant) of a UI element.
-/// Each variant must be an enum with a default case.
-///
-/// Use `.to_class()` to get the class for the variant and `.with_class()` to append a class.
-///
-/// # Example
-///
-/// ```rust
-/// use tailwind_fuse::*;
-///
-/// #[derive(TwVariant, Debug)]
-/// // Optional base class
-/// #[tw(class = "hover:brightness-50")]
-/// enum BtnColor {
-///     #[tw(default, class = "bg-blue-500 text-blue-100")]
-///     Default,
-///     #[tw(class = "bg-red-500 text-red-100")]
-///     Red,
-/// }
-///
-/// assert_eq!(BtnColor::Default.to_class(), "hover:brightness-50 bg-blue-500 text-blue-100");
-///
-/// let red_with_class = BtnColor::Red.with_class("flex");
-/// assert_eq!(red_with_class, "hover:brightness-50 bg-red-500 text-red-100 flex");
-/// ```
-///
-#[cfg(feature = "variant")]
-pub use tailwind_fuse_macro::TwVariant;
 
 pub use crate::core::merge;
 pub use crate::core::*;
@@ -335,12 +253,109 @@ impl TailwindFuse for TailwindJoin {
     }
 }
 
-/// A trait to convert a type into a Tailwind class.
-/// Implemented automatically for usages of [`TwClass`] and [`TwVariant`].
 #[cfg(feature = "variant")]
-pub trait IntoTailwindClass {
-    /// Convert the type into a Tailwind class.
-    fn to_class(&self) -> String;
-    /// Append to the class (with override precedence) and return the new class.
-    fn with_class(&self, class: impl AsRef<str>) -> String;
+pub use variant::*;
+
+#[cfg(feature = "variant")]
+mod variant {
+
+    /// Derives a class for use with Tailwind CSS in Rust components.
+    ///
+    /// Allows building components with first-class support for Tailwind.
+    ///
+    /// Defaults to using [`crate::tw_merge()`] to resolve conflicts.
+    ///
+    /// Resolves conflicts using the following merge order:
+    /// - [`TwClass`] base class
+    /// - [`TwVariant`] base class
+    /// - [`TwVariant`] enum variant class
+    /// - Override class with `with_class`
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use tailwind_fuse::*;
+    ///
+    /// #[derive(TwClass, Debug)]
+    /// // Optional base class.
+    /// #[tw(class = "flex")]
+    /// struct Btn {
+    ///     size: BtnSize,
+    ///     color: BtnColor,
+    /// }
+    ///
+    /// #[derive(TwVariant, Debug)]
+    /// enum BtnSize {
+    ///     #[tw(default, class = "h-9 px-4 py-2")]
+    ///     Default,
+    ///     #[tw(class = "h-8 px-3")]
+    ///     Sm,
+    ///     #[tw(class = "h-10 px-8")]
+    ///     Lg,
+    /// }
+    ///
+    /// #[derive(TwVariant, Debug)]
+    /// enum BtnColor {
+    ///     #[tw(default, class = "bg-blue-500 text-blue-100")]
+    ///     Blue,
+    ///     #[tw(class = "bg-red-500 text-red-100")]
+    ///     Red,
+    /// }
+    ///
+    /// let btn = Btn { size: BtnSize::Default, color: BtnColor::Blue };
+    /// assert_eq!(btn.to_class(), "flex h-9 px-4 py-2 bg-blue-500 text-blue-100");
+    ///
+    /// let btn_variant = Btn::builder().color(BtnColor::Red).to_class();
+    /// assert_eq!(btn_variant, "flex h-9 px-4 py-2 bg-red-500 text-red-100");
+    /// ```
+    ///
+    pub use tailwind_fuse_macro::TwClass;
+
+    /// Represents a customizable property (variant) of a UI element.
+    /// Each variant must be an enum with a default case.
+    ///
+    /// Use `.to_class()` to get the class for the variant and `.with_class()` to append a class.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use tailwind_fuse::*;
+    ///
+    /// #[derive(TwVariant, Debug)]
+    /// // Optional base class
+    /// #[tw(class = "hover:brightness-50")]
+    /// enum BtnColor {
+    ///     #[tw(default, class = "bg-blue-500 text-blue-100")]
+    ///     Default,
+    ///     #[tw(class = "bg-red-500 text-red-100")]
+    ///     Red,
+    /// }
+    ///
+    /// assert_eq!(BtnColor::Default.to_class(), "hover:brightness-50 bg-blue-500 text-blue-100");
+    ///
+    /// let red_with_class = BtnColor::Red.with_class("flex");
+    /// assert_eq!(red_with_class, "hover:brightness-50 bg-red-500 text-red-100 flex");
+    /// ```
+    ///
+    pub use tailwind_fuse_macro::TwVariant;
+
+    /// A trait to convert a type into a Tailwind class.
+    /// Implemented automatically for usages of [`TwClass`] and [`TwVariant`].
+    pub trait IntoTailwindClass {
+        /// Convert the type into a Tailwind class.
+        fn to_class(&self) -> String;
+        /// Append to the class (with override precedence) and return the new class.
+        fn with_class(&self, class: impl AsRef<str>) -> String;
+    }
+
+    /// Converts a type into it's builder.
+    /// Automatically implemented for usages of [`TwClass`].
+    pub trait IntoBuilder {
+        /// The builder type.
+        type Builder;
+        /// Get a builder instance
+        fn builder() -> Self::Builder;
+        /// Convert the instance into the builder.
+        fn into_builder(self) -> Self::Builder;
+    }
 }

--- a/fuse/src/lib.rs
+++ b/fuse/src/lib.rs
@@ -16,14 +16,14 @@
 //!
 //! ## Installation
 //!
-//! Variants requires the `variants` feature to be enabled.
+//! Variants requires the `variant` feature to be enabled.
 //!
-//! #### With variants
+//! #### With variant
 //! ```bash
-//! cargo add tailwind-fuse --features variants
+//! cargo add tailwind-fuse --features variant
 //! ```
 //!
-//! #### Without variants
+//! #### Without variant
 //! ```bash
 //! cargo add tailwind-fuse
 //! ```
@@ -131,11 +131,17 @@
 //!     size: BtnSize::Default,
 //!     color: BtnColor::Blue,
 //! };
-//! // h-9 px-4 py-2 bg-blue-500 text-blue-100
-//! button.to_class();
-//! // Conflicts are resolved.
-//! // h-9 px-4 py-2 text-blue-100 bg-green-500
-//! button.with_class("bg-green-500");
+//!
+//! assert_eq!(
+//!    "flex h-9 px-4 py-2 bg-blue-500 text-blue-100",
+//!    button.to_class()
+//! );
+//!
+//! // Conflicts are resolved (bg-blue-500 is knocked out in favor of override)
+//! assert_eq!(
+//!    "flex h-9 px-4 py-2 text-blue-100 bg-green-500",
+//!    button.with_class("bg-green-500")
+//! );
 //! ```
 //!
 //! ### Builder Syntax
@@ -172,17 +178,22 @@
 //! #     Red,
 //! # }
 //!
-//! // h-8 px-3 bg-red-500 text-red-100
-//! let class = Btn::builder()
-//!     .size(BtnSize::Sm)
-//!     .color(BtnColor::Red)
-//!     .to_class();
+//! assert_eq!(
+//!    "flex h-8 px-3 bg-red-500 text-red-100",
+//!    Btn::builder()
+//!       .size(BtnSize::Sm)
+//!       .color(BtnColor::Red)
+//!       .to_class()
+//! );
 //!
-//! // h-8 px-3 text-red-100 bg-green-500
-//! let class = Btn::builder()
-//!     .size(BtnSize::Sm)
-//!     .color(BtnColor::Red)
-//!     .with_class("bg-green-500");
+//! assert_eq!(
+//!    "flex h-8 px-3 text-red-100 bg-green-500",
+//!    Btn::builder()
+//!       .size(BtnSize::Sm)
+//!       .color(BtnColor::Red)
+//!       .with_class("bg-green-500")
+//! );
+//!
 //! ```
 //!
 //! #### VSCode Intellisense
@@ -208,46 +219,45 @@ pub use crate::core::*;
 mod ast;
 mod core;
 
-/// Used to Fuse Tailwind Classes together.
-pub trait TailwindFuse {
-    /// Strings are not guaranteed to be single class nor free of whitespace.
-    fn fuse_classes(&self, class: &[&str]) -> String;
-}
-
-/// Will merge Tailwind classes and handle conflicts using [`tw_merge()`]
-pub struct TailwindMerge;
-
-impl TailwindFuse for TailwindMerge {
-    fn fuse_classes(&self, class: &[&str]) -> String {
-        crate::core::merge::tw_merge_slice(class)
-    }
-}
-
-/// Will simply join Tailwind classes together without handling conflicts
-pub struct TailwindJoin;
-
-impl TailwindFuse for TailwindJoin {
-    fn fuse_classes(&self, class: &[&str]) -> String {
-        class
-            .iter()
-            .flat_map(|s| s.split_whitespace())
-            .map(|s| s.trim())
-            .filter(|s| !s.is_empty())
-            .fold(String::new(), |mut acc, s| {
-                if !acc.is_empty() {
-                    acc.push(' ');
-                }
-                acc.push_str(s);
-                acc
-            })
-    }
-}
-
 #[cfg(feature = "variant")]
 pub use variant::*;
 
 #[cfg(feature = "variant")]
 mod variant {
+    /// Used to Fuse Tailwind Classes together.
+    pub trait TailwindFuse {
+        /// Strings are not guaranteed to be single class nor free of whitespace.
+        fn fuse_classes(&self, class: &[&str]) -> String;
+    }
+
+    /// Will merge Tailwind classes and handle conflicts using [`tw_merge()`]
+    pub struct TailwindMerge;
+
+    impl TailwindFuse for TailwindMerge {
+        fn fuse_classes(&self, class: &[&str]) -> String {
+            crate::core::merge::tw_merge_slice(class)
+        }
+    }
+
+    /// Will simply join Tailwind classes together without handling conflicts
+    pub struct TailwindJoin;
+
+    impl TailwindFuse for TailwindJoin {
+        fn fuse_classes(&self, class: &[&str]) -> String {
+            class
+                .iter()
+                .flat_map(|s| s.split_whitespace())
+                .map(|s| s.trim())
+                .filter(|s| !s.is_empty())
+                .fold(String::new(), |mut acc, s| {
+                    if !acc.is_empty() {
+                        acc.push(' ');
+                    }
+                    acc.push_str(s);
+                    acc
+                })
+        }
+    }
 
     /// Derives a class for use with Tailwind CSS in Rust components.
     ///

--- a/fuse/tests/variant-macro.rs
+++ b/fuse/tests/variant-macro.rs
@@ -3,17 +3,17 @@ use tailwind_fuse::*;
 #[derive(TwVariant, Debug, PartialEq)]
 enum BtnColor {
     #[tw(default, class = "bg-blue-500 text-blue-100")]
-    Default,
+    Blue,
     #[tw(class = "bg-red-500 text-red-100")]
     Red,
 }
 
 #[test]
 fn btn_color() {
-    assert_eq!(BtnColor::Default.as_class(), "bg-blue-500 text-blue-100");
+    assert_eq!(BtnColor::Blue.as_class(), "bg-blue-500 text-blue-100");
     assert_eq!(BtnColor::Red.as_class(), "bg-red-500 text-red-100");
 
-    assert_eq!(BtnColor::default(), BtnColor::Default);
+    assert_eq!(BtnColor::default(), BtnColor::Blue);
 }
 
 #[test]
@@ -22,11 +22,11 @@ fn btn_color_with_default() {
     #[tw(class = "text-white")]
     enum BtnColor {
         #[tw(default, class = "bg-blue-500")]
-        Default,
+        Blue,
         #[tw(class = "bg-red-500")]
         Red,
     }
-    assert_eq!(BtnColor::Default.as_class(), "text-white bg-blue-500");
+    assert_eq!(BtnColor::Blue.as_class(), "text-white bg-blue-500");
     assert_eq!(BtnColor::Red.as_class(), "text-white bg-red-500");
 }
 
@@ -115,5 +115,13 @@ fn test_class_builder() {
     assert_eq!(
         Btn::builder().with_class("grid"),
         "h-9 px-4 py-2 bg-blue-500 text-blue-100 grid"
+    );
+}
+
+#[test]
+fn variant_join() {
+    assert_eq!(
+        tw_merge!(BtnColor::Blue, "text-lg",),
+        "bg-blue-500 text-blue-100 text-lg"
     );
 }

--- a/fuse/tests/variant-macro.rs
+++ b/fuse/tests/variant-macro.rs
@@ -10,12 +10,11 @@ enum BtnColor {
 
 #[test]
 fn btn_color() {
-    assert_eq!(BtnColor::Default.to_class(), "bg-blue-500 text-blue-100");
-    assert_eq!(BtnColor::Red.to_class(), "bg-red-500 text-red-100");
     assert_eq!(
-        BtnColor::Default.with_class("text-lg"),
-        "bg-blue-500 text-blue-100 text-lg"
+        BtnColor::Default.as_tailwind_class(),
+        "bg-blue-500 text-blue-100"
     );
+    assert_eq!(BtnColor::Red.as_tailwind_class(), "bg-red-500 text-red-100");
 
     assert_eq!(BtnColor::default(), BtnColor::Default);
 }
@@ -30,12 +29,11 @@ fn btn_color_with_default() {
         #[tw(class = "bg-red-500")]
         Red,
     }
-    assert_eq!(BtnColor::Default.to_class(), "text-white bg-blue-500");
-    assert_eq!(BtnColor::Red.to_class(), "text-white bg-red-500");
     assert_eq!(
-        BtnColor::Default.with_class("text-lg"),
-        "text-white bg-blue-500 text-lg"
+        BtnColor::Default.as_tailwind_class(),
+        "text-white bg-blue-500"
     );
+    assert_eq!(BtnColor::Red.as_tailwind_class(), "text-white bg-red-500");
 }
 
 #[derive(TwVariant)]

--- a/fuse/tests/variant-macro.rs
+++ b/fuse/tests/variant-macro.rs
@@ -95,7 +95,7 @@ fn test_btn_no_merge() {
 #[test]
 fn test_class_builder() {
     assert_eq!(
-        Btn::variant()
+        Btn::builder()
             .size(BtnSize::Sm)
             .color(BtnColor::Red)
             .to_class(),
@@ -103,7 +103,7 @@ fn test_class_builder() {
     );
 
     assert_eq!(
-        Btn::variant()
+        Btn::builder()
             .size(BtnSize::Sm)
             .color(BtnColor::Red)
             .with_class("flex"),
@@ -111,17 +111,17 @@ fn test_class_builder() {
     );
 
     assert_eq!(
-        Btn::variant().size(BtnSize::Lg).to_class(),
+        Btn::builder().size(BtnSize::Lg).to_class(),
         "h-10 rounded-lg px-8 bg-blue-500 text-blue-100"
     );
 
     assert_eq!(
-        Btn::variant().to_class(),
+        Btn::builder().to_class(),
         "h-9 px-4 py-2 bg-blue-500 text-blue-100"
     );
 
     assert_eq!(
-        Btn::variant().with_class("grid"),
+        Btn::builder().with_class("grid"),
         "h-9 px-4 py-2 bg-blue-500 text-blue-100 grid"
     );
 }

--- a/fuse/tests/variant-macro.rs
+++ b/fuse/tests/variant-macro.rs
@@ -10,11 +10,8 @@ enum BtnColor {
 
 #[test]
 fn btn_color() {
-    assert_eq!(
-        BtnColor::Default.as_tailwind_class(),
-        "bg-blue-500 text-blue-100"
-    );
-    assert_eq!(BtnColor::Red.as_tailwind_class(), "bg-red-500 text-red-100");
+    assert_eq!(BtnColor::Default.as_class(), "bg-blue-500 text-blue-100");
+    assert_eq!(BtnColor::Red.as_class(), "bg-red-500 text-red-100");
 
     assert_eq!(BtnColor::default(), BtnColor::Default);
 }
@@ -29,11 +26,8 @@ fn btn_color_with_default() {
         #[tw(class = "bg-red-500")]
         Red,
     }
-    assert_eq!(
-        BtnColor::Default.as_tailwind_class(),
-        "text-white bg-blue-500"
-    );
-    assert_eq!(BtnColor::Red.as_tailwind_class(), "text-white bg-red-500");
+    assert_eq!(BtnColor::Default.as_class(), "text-white bg-blue-500");
+    assert_eq!(BtnColor::Red.as_class(), "text-white bg-red-500");
 }
 
 #[derive(TwVariant)]

--- a/variant-macro/src/class_macro.rs
+++ b/variant-macro/src/class_macro.rs
@@ -91,13 +91,13 @@ pub fn class_impl(input: TokenStream) -> TokenStream {
     let builder_to_tailwind = {
         let builder_variables = field_class_strings.iter().map(|(field_name, var_name)| {
             quote! {
-                let #var_name = self.#field_name.as_ref().unwrap_or(&Default::default()).to_class();
+                let #var_name = self.#field_name.unwrap_or_default();
             }
         });
 
         let builder_refs = field_class_strings.iter().map(|(_, var_name)| {
             quote! {
-                #var_name.as_str(),
+                #var_name.as_tailwind_class(),
             }
         });
 
@@ -123,16 +123,15 @@ pub fn class_impl(input: TokenStream) -> TokenStream {
     // First need to save the String to a local variable.
 
     let struct_to_tailwind = {
-        let field_variables = field_class_strings.iter().map(|(field_name, var_name)| {
+        let field_vars = field_class_strings.iter().map(|(field_name, var_name)| {
             quote! {
-                let #var_name = self.#field_name.to_class();
+                let #var_name = self.#field_name.as_tailwind_class();
             }
         });
 
-        // Then we borrow the local variable to get the reference.
         let field_refs = field_class_strings.iter().map(|(_, var_name)| {
             quote! {
-                #var_name.as_str(),
+                #var_name,
             }
         });
 
@@ -143,7 +142,7 @@ pub fn class_impl(input: TokenStream) -> TokenStream {
                 }
 
                 fn with_class(&self, class: impl AsRef<str>) -> String {
-                    #( #field_variables )*
+                    #( #field_vars )*
                     let classes = [
                         #base_class,
                         #( #field_refs )*

--- a/variant-macro/src/class_macro.rs
+++ b/variant-macro/src/class_macro.rs
@@ -118,6 +118,10 @@ pub fn class_impl(input: TokenStream) -> TokenStream {
     };
 
     let gen = quote! {
+        #builder_struct
+
+        #builder_impl
+
         impl IntoBuilder for #struct_ident {
             type Builder = #builder_ident;
 
@@ -142,10 +146,6 @@ pub fn class_impl(input: TokenStream) -> TokenStream {
                 value.build()
             }
         }
-
-        #builder_struct
-
-        #builder_impl
 
         #builder_to_tailwind
 

--- a/variant-macro/src/class_macro.rs
+++ b/variant-macro/src/class_macro.rs
@@ -33,38 +33,69 @@ pub fn class_impl(input: TokenStream) -> TokenStream {
         }
     };
 
+    let builder_struct = {
+        let builder_fields = fields.iter().map(|field| {
+            let TwClassField { ident, ty, .. } = field;
+            quote! { #ident: Option<#ty> }
+        });
+
+        quote! {
+            pub struct #builder_ident {
+                #(#builder_fields,)*
+            }
+        }
+    };
+
     let field_idents = fields
         .iter()
         .map(|field| field.ident.as_ref().unwrap().clone());
 
-    let builder_fields = fields.iter().map(|field| {
-        let TwClassField { ident, ty, .. } = field;
-        quote! { #ident: Option<#ty> }
-    });
+    let builder_impl = {
+        let field_idents = field_idents.clone();
 
-    let builder_set_methods = fields.iter().map(|field| {
-        let TwClassField { ident, ty, .. } = field;
+        let builder_set_methods = fields.iter().map(|field| {
+            let TwClassField { ident, ty, .. } = field;
+            quote! {
+                pub fn #ident(mut self, value: #ty) -> Self {
+                    self.#ident = Some(value);
+                    self
+                }
+            }
+        });
+
         quote! {
-            pub fn #ident(mut self, value: #ty) -> Self {
-                self.#ident = Some(value);
-                self
+            impl #builder_ident {
+                #(#builder_set_methods)*
+
+                pub fn build(self) -> #struct_ident {
+                    #struct_ident {
+                        #(#field_idents: self.#field_idents.unwrap_or_default(),)*
+                    }
+                }
             }
         }
-    });
+    };
 
-    let builder_to_tailwind = {
-        let optional_builder_field_strings = fields.iter().enumerate().map(|(i, field)| {
+    let field_class_strings: Vec<(&Option<syn::Ident>, syn::Ident)> = fields
+        .iter()
+        .enumerate()
+        .map(|(i, field)| {
             let field_name = &field.ident;
             let var_name =
                 syn::Ident::new(&format!("class_str_{}", i), proc_macro2::Span::call_site());
+
+            (field_name, var_name)
+        })
+        .collect::<Vec<_>>();
+
+    let builder_to_tailwind = {
+        let builder_variables = field_class_strings.iter().map(|(field_name, var_name)| {
             quote! {
                 let #var_name = self.#field_name.as_ref().unwrap_or(&Default::default()).to_class();
             }
         });
 
-        let optional_builder_field_refs = fields.iter().enumerate().map(|(i, _)| {
-            let var_name =
-                syn::Ident::new(&format!("class_str_{}", i), proc_macro2::Span::call_site());
+        let builder_refs = field_class_strings.iter().map(|(_, var_name)| {
             quote! {
                 #var_name.as_str(),
             }
@@ -77,10 +108,10 @@ pub fn class_impl(input: TokenStream) -> TokenStream {
                 }
 
                 fn with_class(&self, class: impl AsRef<str>) -> String {
-                    #( #optional_builder_field_strings )*
+                    #( #builder_variables )*
                     let classes = [
                         #base_class,
-                        #( #optional_builder_field_refs )*
+                        #( #builder_refs )*
                         class.as_ref(),
                     ];
                     #merger.fuse_classes(&classes)
@@ -88,22 +119,18 @@ pub fn class_impl(input: TokenStream) -> TokenStream {
             }
         }
     };
+    // We have code duplication here because we can't ensure that clone is implemented for all types.
+    // First need to save the String to a local variable.
 
     let struct_to_tailwind = {
-        // Need to save the String to a local variable.
-        let field_class_strings = fields.iter().enumerate().map(|(i, field)| {
-            let field_name = &field.ident;
-            let var_name =
-                syn::Ident::new(&format!("class_str_{}", i), proc_macro2::Span::call_site());
+        let field_variables = field_class_strings.iter().map(|(field_name, var_name)| {
             quote! {
                 let #var_name = self.#field_name.to_class();
             }
         });
 
         // Then we borrow the local variable to get the reference.
-        let field_class_refs = fields.iter().enumerate().map(|(i, _)| {
-            let var_name =
-                syn::Ident::new(&format!("class_str_{}", i), proc_macro2::Span::call_site());
+        let field_refs = field_class_strings.iter().map(|(_, var_name)| {
             quote! {
                 #var_name.as_str(),
             }
@@ -116,10 +143,10 @@ pub fn class_impl(input: TokenStream) -> TokenStream {
                 }
 
                 fn with_class(&self, class: impl AsRef<str>) -> String {
-                    #( #field_class_strings )*
+                    #( #field_variables )*
                     let classes = [
                         #base_class,
-                        #( #field_class_refs )*
+                        #( #field_refs )*
                         class.as_ref(),
                     ];
                     #merger.fuse_classes(&classes)
@@ -128,23 +155,52 @@ pub fn class_impl(input: TokenStream) -> TokenStream {
         }
     };
 
+    let builder_default = {
+        let field_idents = field_idents.clone();
+
+        quote! {
+            impl Default for #builder_ident {
+                fn default() -> Self {
+                    #builder_ident {
+                        #(#field_idents: None,)*
+                    }
+                }
+            }
+        }
+    };
+
     let gen = quote! {
-        impl #struct_ident {
-            pub fn variant() -> #builder_ident {
+        impl IntoBuilder for #struct_ident {
+            type Builder = #builder_ident;
+
+            fn builder() -> Self::Builder {
+                Default::default()
+            }
+            fn into_builder(self) -> Self::Builder {
+                self.into()
+            }
+        }
+
+        impl From<#struct_ident> for #builder_ident {
+            fn from(value: #struct_ident) -> Self {
                 #builder_ident {
-                    #(#field_idents: None,)*
+                    #(#field_idents: Some(value.#field_idents),)*
                 }
             }
         }
 
-        pub struct #builder_ident {
-            #(#builder_fields,)*
+        impl From<#builder_ident> for #struct_ident {
+            fn from(value: #builder_ident) -> Self {
+                value.build()
+            }
         }
 
-        impl #builder_ident {
-            #(#builder_set_methods)*
+        #builder_default
 
-        }
+        #builder_struct
+
+        #builder_impl
+
         #builder_to_tailwind
 
         #struct_to_tailwind

--- a/variant-macro/src/class_macro.rs
+++ b/variant-macro/src/class_macro.rs
@@ -85,7 +85,7 @@ pub fn class_impl(input: TokenStream) -> TokenStream {
                 }
 
                 fn with_class(&self, class: impl AsRef<str>) -> String {
-                    self.clone().build().with_class(class)
+                    (*self).build().with_class(class)
                 }
             }
         }

--- a/variant-macro/src/model.rs
+++ b/variant-macro/src/model.rs
@@ -29,6 +29,8 @@ pub struct TwClassContainer {
     pub class: Option<String>,
     /// Defaults to using `tw_merge`.
     pub merger: Option<IdentString>,
+    /// If true, the builder will implement `Clone`.
+    pub clone: Flag,
 }
 
 #[derive(Debug, FromField)]

--- a/variant-macro/src/model.rs
+++ b/variant-macro/src/model.rs
@@ -29,8 +29,6 @@ pub struct TwClassContainer {
     pub class: Option<String>,
     /// Defaults to using `tw_merge`.
     pub merger: Option<IdentString>,
-    /// If true, the builder will implement `Clone`.
-    pub clone: Flag,
 }
 
 #[derive(Debug, FromField)]

--- a/variant-macro/src/variant_macro.rs
+++ b/variant-macro/src/variant_macro.rs
@@ -67,7 +67,7 @@ pub fn variant_impl(input: TokenStream) -> TokenStream {
         }
     });
 
-    let gen = quote! {
+    let into_tailwind = quote! {
         impl IntoTailwindClass for #enum_ident {
             fn to_class(&self) -> String {
                 self.with_class("")
@@ -79,8 +79,19 @@ pub fn variant_impl(input: TokenStream) -> TokenStream {
                 tw_join!(#base_class, variant_class, class.as_ref())
             }
         }
+    };
 
+    let gen = quote! {
         #default_variant
+
+        #into_tailwind
+
+        impl Copy for #enum_ident {}
+        impl Clone for #enum_ident {
+            fn clone(&self) -> Self {
+                *self
+            }
+        }
     };
 
     gen.into()


### PR DESCRIPTION
- Use `format!` macro inside `tw_join!` and `tw_merge!`
- `MaybeIntoTailwindClass` trait is now replaced by  `AsTailwindClass`
   Removes support for `Option` in `tw_join!` and `tw_merge!`
   
- `TwVariant` macro will force implement Copy and Clone
- Create constants for all `TwVariant` instances (concat! on base class if present)
- Remove impl of `IntoTailwindClass` for `TwVariant` in favor of `AsTailwindClass` because we don't want to needlessly allocate strings
   - Enables usage with `tw_join!` and `tw_merge!` macros

- `TwClass` builder method will be more traditional
   - `.builder()` will create builder instance (instead of `variant()` which was confusing)
   - `.build()` (NEW) will convert builder instance into `TwClass` type
   - From Builder -> T
   - From T -> Builder
   - Builder will be Copy and Clone

- `TwClass` struct can be Copy and Clone, and is not implemented automatically. User can decide by applying derive macros themselves. 
   
