### PR TITLE
Allow Option in tw_join! and tw_merge! macros

### DIFF
--- a/fuse/src/core/mod.rs
+++ b/fuse/src/core/mod.rs
@@ -19,7 +19,7 @@ impl AsTailwindClass for String {
 
 impl AsTailwindClass for &str {
     fn as_class(&self) -> &str {
-        *self
+        self
     }
 }
 

--- a/fuse/src/core/mod.rs
+++ b/fuse/src/core/mod.rs
@@ -11,11 +11,77 @@ pub trait AsTailwindClass {
     fn as_class(&self) -> &str;
 }
 
-impl<T> AsTailwindClass for T
+impl AsTailwindClass for String {
+    fn as_class(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl AsTailwindClass for &str {
+    fn as_class(&self) -> &str {
+        *self
+    }
+}
+
+impl<T> AsTailwindClass for &T
 where
-    T: AsRef<str>,
+    T: AsTailwindClass,
 {
     fn as_class(&self) -> &str {
+        (*self).as_class()
+    }
+}
+
+impl<T> AsTailwindClass for &mut T
+where
+    T: AsTailwindClass,
+{
+    fn as_class(&self) -> &str {
+        (**self).as_class()
+    }
+}
+
+impl<T> AsTailwindClass for std::rc::Rc<T>
+where
+    T: AsTailwindClass,
+{
+    fn as_class(&self) -> &str {
+        self.as_ref().as_class()
+    }
+}
+
+impl<T> AsTailwindClass for std::sync::Arc<T>
+where
+    T: AsTailwindClass,
+{
+    fn as_class(&self) -> &str {
+        self.as_ref().as_class()
+    }
+}
+
+impl AsTailwindClass for std::borrow::Cow<'_, str> {
+    fn as_class(&self) -> &str {
         self.as_ref()
+    }
+}
+
+impl<T> AsTailwindClass for Box<T>
+where
+    T: AsTailwindClass,
+{
+    fn as_class(&self) -> &str {
+        (**self).as_class()
+    }
+}
+
+impl<T> AsTailwindClass for Option<T>
+where
+    T: AsTailwindClass,
+{
+    fn as_class(&self) -> &str {
+        match self {
+            Some(t) => t.as_class(),
+            None => "",
+        }
     }
 }

--- a/fuse/src/lib.rs
+++ b/fuse/src/lib.rs
@@ -236,7 +236,7 @@ mod variant {
 
     impl TailwindFuse for TailwindMerge {
         fn fuse_classes(&self, class: &[&str]) -> String {
-            crate::core::merge::tw_merge_slice(class)
+            crate::merge::tw_merge_slice(class)
         }
     }
 


### PR DESCRIPTION
Remove single AsRef impl for `AsTailwindClass` in favor of multiple granular implementations.

Closes https://github.com/gaucho-labs/tailwind-fuse/issues/18