### PR TITLE
Global Tailwind Config Override: Compile Time Env Value

### DIFF
--- a/example/start-axum/.cargo/config.toml
+++ b/example/start-axum/.cargo/config.toml
@@ -1,0 +1,2 @@
+[env]
+TW_PREFIX = "tw-"

--- a/example/start-axum/Cargo.lock
+++ b/example/start-axum/Cargo.lock
@@ -1979,11 +1979,20 @@ checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "tailwind_fuse"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
- "tw_fuse",
- "tw_utils",
- "tw_variant_macro",
+ "nom",
+ "tailwind_fuse_macro",
+]
+
+[[package]]
+name = "tailwind_fuse_macro"
+version = "0.2.0"
+dependencies = [
+ "darling 0.20.8",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -2191,37 +2200,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tw_ast"
-version = "0.1.0"
-dependencies = [
- "nom",
-]
-
-[[package]]
-name = "tw_fuse"
-version = "0.1.0"
-dependencies = [
- "nom",
- "tw_ast",
-]
-
-[[package]]
-name = "tw_utils"
-version = "0.1.0"
-
-[[package]]
-name = "tw_variant_macro"
-version = "0.1.0"
-dependencies = [
- "darling 0.20.8",
- "proc-macro2",
- "quote",
- "syn 2.0.52",
- "tw_fuse",
- "tw_utils",
-]
-
-[[package]]
 name = "typed-builder"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2333,9 +2311,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.89"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ed0d4f68a3015cc185aff4db9506a015f4b96f95303897bfa23f846db54064e"
+checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -2343,9 +2321,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.89"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b56f625e64f3a1084ded111c4d5f477df9f8c92df113852fa5a374dbda78826"
+checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
 dependencies = [
  "bumpalo",
  "log",
@@ -2370,9 +2348,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.89"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0162dbf37223cd2afce98f3d0785506dcb8d266223983e4b5b525859e6e182b2"
+checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2380,9 +2358,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.89"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0eb82fcb7930ae6219a7ecfd55b217f5f0893484b7a13022ebb2b2bf20b5283"
+checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2393,9 +2371,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.89"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ab9b36309365056cd639da3134bf87fa8f3d86008abf99e612384a6eecd459f"
+checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
 
 [[package]]
 name = "wasm-streams"

--- a/example/start-axum/Cargo.toml
+++ b/example/start-axum/Cargo.toml
@@ -16,11 +16,11 @@ leptos_router = { version = "0.6", features = ["nightly"] }
 tokio = { version = "1", features = ["rt-multi-thread"], optional = true }
 tower = { version = "0.4", optional = true }
 tower-http = { version = "0.5", features = ["fs"], optional = true }
-wasm-bindgen = "=0.2.89"
+wasm-bindgen = "=0.2.92"
 thiserror = "1"
 tracing = { version = "0.1", optional = true }
 http = "1"
-tailwind_fuse = { path = "../../public", features = ["variant"]}
+tailwind_fuse = { path = "../../fuse", features = ["variant", "debug"]}
 
 [features]
 hydrate = ["leptos/hydrate", "leptos_meta/hydrate", "leptos_router/hydrate"]

--- a/example/start-axum/src/app.rs
+++ b/example/start-axum/src/app.rs
@@ -2,9 +2,10 @@ use crate::{
     button::{BtnSize, BtnVariant, Button},
     error_template::{AppError, ErrorTemplate},
 };
-use leptos::*;
+use leptos::{logging::log, *};
 use leptos_meta::*;
 use leptos_router::*;
+use tailwind_fuse::{merge::MergeOptions, *};
 
 #[component]
 pub fn App() -> impl IntoView {
@@ -39,8 +40,12 @@ fn HomePage() -> impl IntoView {
     let (count, set_count) = create_signal(0);
     let on_click = move |_| set_count.update(|count| *count += 1);
 
+    let options = MergeOptions::default();
+    log!("MergeOptions {options:?}");
+
     view! {
-        <div class="flex items-center gap-4 p-10">
+        // flex-row should be removed.
+        <div class=tw_merge!("tw-flex tw-items-center tw-gap-4 tw-p-10 tw-flex-row", "tw-flex-col")>
             <Button on:click=on_click size=BtnSize::Lg>
                 "Click Me: "
                 {count}

--- a/example/start-axum/tailwind.config.js
+++ b/example/start-axum/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
     module.exports = {
+      prefix: "tw-",
       content: {
         relative: true,
         files: ["*.html", "./src/**/*.rs"],

--- a/fuse/benches/merge.rs
+++ b/fuse/benches/merge.rs
@@ -1,5 +1,5 @@
 use divan::Bencher;
-use tailwind_fuse::merge::{tw_merge, tw_merge_slice};
+use tailwind_fuse::merge::{tw_merge, tw_merge_slice_options};
 
 fn main() {
     divan::main();
@@ -28,7 +28,7 @@ fn tailwind_merge(bencher: Bencher, len: usize) {
 fn tailwind_merge_slice(bencher: Bencher, len: usize) {
     bencher
         .with_inputs(|| generate_random_classes(len))
-        .bench_values(|class| tw_merge_slice(&class));
+        .bench_values(|class| tw_merge_slice_options(&class, Default::default()));
 }
 
 // create a vec with the a length of len and fill it with random data

--- a/fuse/src/core/merge/merge_impl.rs
+++ b/fuse/src/core/merge/merge_impl.rs
@@ -7,7 +7,8 @@ use crate::core::merge::get_collisions::get_collisions;
 
 /// Merges all the Tailwind classes, resolving conflicts.
 /// Can supply custom options, collision_id_fn and collisions_fn.
-pub fn tw_merge_with_override(
+#[inline]
+pub fn tw_merge_override(
     class: &[&str],
     options: MergeOptions,
     collision_id_fn: impl CollisionIdFn,

--- a/fuse/src/lib.rs
+++ b/fuse/src/lib.rs
@@ -254,7 +254,7 @@ mod variant {
 
     impl TailwindFuse for TailwindMerge {
         fn fuse_classes(&self, class: &[&str]) -> String {
-            crate::merge::tw_merge_slice(class)
+            crate::merge::tw_merge_slice_options(class, Default::default())
         }
     }
 

--- a/fuse/tests/override.rs
+++ b/fuse/tests/override.rs
@@ -1,9 +1,9 @@
-use tailwind_fuse::merge::{tw_merge_with_options, tw_merge_with_override, MergeOptions};
+use tailwind_fuse::merge::{tw_merge_options, tw_merge_override, MergeOptions};
 
 #[test]
 fn test_collisions() {
     pub fn tw_merge(class: &str) -> String {
-        tw_merge_with_override(
+        tw_merge_override(
             &[class],
             Default::default(),
             collision_id_fn,
@@ -47,11 +47,11 @@ fn test_override_config() {
     };
 
     let class = "hover|lg|tw-bg-blue-100 hover|lg|tw-bg-red-500";
-    let result = tw_merge_with_options(class, config);
+    let result = tw_merge_options(class, config);
     assert_eq!("hover|lg|tw-bg-red-500", result);
 
     let class = "tw-bg-blue-100 bg-red-500";
-    let result = tw_merge_with_options(class, config);
+    let result = tw_merge_options(class, config);
     assert_eq!(
         class, result,
         "No conflict because non-prefix is not considered tailwind class"


### PR DESCRIPTION
closes https://github.com/gaucho-labs/tailwind-fuse/issues/12

The main idea here is to use env values inside `.cargo/config.toml` to override the tailwind prefix (TW_PREFIX) and separator (TW_SEPARATOR). This should be done at compile time using `option_env!` to avoid performance issues. 

This is the cleanest way that I can think of, and allows users to use all the macros with minimal setup