### PR TITLE
Match Tailwind All-Sides border width utilities as border widths instead of border colors.

### DIFF
--- a/fuse/src/core/merge/get_collision_id.rs
+++ b/fuse/src/core/merge/get_collision_id.rs
@@ -500,7 +500,8 @@ pub fn get_collision_id(classes: &[&str], arbitrary: &str) -> Result<&'static st
         ["border", "l"] if arbitrary.is_empty() || is_arbitrary_len(arbitrary) => Ok("border-w-l"),
         ["border", "s", rest] if is_valid_length(rest) => Ok("border-w-s"),
         ["border", "s"] if arbitrary.is_empty() || is_arbitrary_len(arbitrary) => Ok("border-w-s"),
-        ["border"] if arbitrary.is_empty() => Ok("border-w"),
+        ["border", rest] if is_valid_length(rest) => Ok("border-w"),
+        ["border"] if arbitrary.is_empty() || is_arbitrary_len(arbitrary) => Ok("border-w"),
 
         // https://tailwindcss.com/docs/border-style
         ["border", "solid" | "dashed" | "dotted" | "double" | "hidden" | "none"] => {

--- a/fuse/tests/group-conflicts.rs
+++ b/fuse/tests/group-conflicts.rs
@@ -2,6 +2,15 @@ use tailwind_fuse::merge::tw_merge;
 use tailwind_fuse::tw_merge;
 
 #[test]
+fn test_tw_merge_border_width_color() {
+    let all_sides = tw_merge!("border-2", "border-blue-500");
+    assert_eq!(all_sides, "border-2 border-blue-500");
+
+    let arbitrary = tw_merge!("border-[100px]", "border-blue-500");
+    assert_eq!(arbitrary, "border-[100px] border-blue-500");
+}
+
+#[test]
 fn test_tw_merge_mixed_blend() {
     let classes = tw_merge!("mix-blend-normal", "mix-blend-multiply");
     assert_eq!(classes, "mix-blend-multiply");


### PR DESCRIPTION
Trying to make a thicker blue border with the utilities "border-2" and "border-blue-500". The width was recognized as a color and the conflict resolution produced the merged class "border-blue-500". The expected result would have been "border-2 border-blue-500".

Tailwind allows for all border sides to be set at once in a similar manner to setting individual sides, just without the side selector. The collision id assignment function was updated to handle these cases in a similar manner to the side-specific ones.