### PR TITLE
fix: parse `group-data-[...]` variants so `!p-*` classes merge properly

### DIFF
--- a/fuse/src/ast/parser.rs
+++ b/fuse/src/ast/parser.rs
@@ -107,7 +107,7 @@ fn parse_normal_variant(input: &str) -> IResult<&str, ASTVariant> {
 // https://tailwindcss.com/docs/hover-focus-and-other-states#supports-rules
 #[inline]
 fn parse_data_attribute_variant(input: &str) -> IResult<&str, ASTVariant> {
-    let tag_prefix = alt((tag("data-"), tag("supports-")));
+    let tag_prefix = alt((tag("data-"), tag("supports-"), tag("group-data-")));
     let mut parser = delimited(tag_prefix, take_till1(|c| c == ']'), tag("]"));
     let (rest, _) = parser(input)?;
     let entire_variant = &input[..input.len() - rest.len()];

--- a/fuse/tests/group_conflicts.rs
+++ b/fuse/tests/group_conflicts.rs
@@ -219,3 +219,23 @@ fn handles_negative_value_conflicts_correctly() {
 fn tailwind_3_4() {
     assert_eq!(tw_merge("text-red text-lg/8"), "text-red text-lg/8");
 }
+
+#[test]
+fn test_group_data_important_modifiers() {
+    let classes = tw_merge!("group-data-[collapsible=icon]:!p-2", "group-data-[collapsible=icon]:!p-0");
+    assert_eq!(classes, "group-data-[collapsible=icon]:!p-0");
+
+    let classes = tw_merge!(
+        "group-data-[collapsible=icon]:!size-8",
+        "group-data-[collapsible=icon]:!p-2",
+        "group-data-[collapsible=icon]:!p-0"
+    );
+    assert_eq!(classes, "group-data-[collapsible=icon]:!size-8 group-data-[collapsible=icon]:!p-0");
+
+    let classes = tw_merge!(
+        "group-data-[collapsible=icon]:!p-2",
+        "group-data-[collapsible=icon]:!size-8",
+        "group-data-[collapsible=icon]:!p-0"
+    );
+    assert_eq!(classes, "group-data-[collapsible=icon]:!size-8 group-data-[collapsible=icon]:!p-0");
+}


### PR DESCRIPTION
**What**  
1. **Add** `"group-data-"` prefix to the `parse_data_attribute_variant` function so the parser recognizes `group-data-[collapsible=icon]` (similar to `"data-[open]"`).  
2. **Add** a new `test_group_data_important_modifiers` in `tests/group_conflicts.rs` to verify that classes like `!p-2` and `!p-0` properly merge into only the last one:

```rust
#[test]
fn test_group_data_important_modifiers() {
    let classes = tw_merge!("group-data-[collapsible=icon]:!p-2", "group-data-[collapsible=icon]:!p-0");
    assert_eq!(classes, "group-data-[collapsible=icon]:!p-0");

    let classes = tw_merge!(
        "group-data-[collapsible=icon]:!size-8",
        "group-data-[collapsible=icon]:!p-2",
        "group-data-[collapsible=icon]:!p-0"
    );
    assert_eq!(classes, "group-data-[collapsible=icon]:!size-8 group-data-[collapsible=icon]:!p-0");

    let classes = tw_merge!(
        "group-data-[collapsible=icon]:!p-2",
        "group-data-[collapsible=icon]:!size-8",
        "group-data-[collapsible=icon]:!p-0"
    );
    assert_eq!(classes, "group-data-[collapsible=icon]:!size-8 group-data-[collapsible=icon]:!p-0");
}
```

**Why**  
- Tailwind 3.2 supports `group-data-[...]` for data attributes, but our parser treated them as invalid (`Err(...)`), causing classes to stack up instead of overriding.  
- This was discovered while reproducing the `SidebarMenuButton` component from [leptos-shadcn-ui in the RustForWeb project](https://github.com/RustForWeb/shadcn-ui), where `!p-0` was not overriding `!p-2` as intended.

**Verification**  
- With this parser fix, `tw_merge!` correctly sees `group-data-[collapsible=icon]:!p-2` and `group-data-[collapsible=icon]:!p-0` as collisions on the same property, leaving only the final (i.e., last) class as expected in Tailwind’s “last wins” approach.

- [x] All tests run successfully
- [x] Ready for review and merge
- Closes #26
